### PR TITLE
Remove rogue backtick in "IR":"Iran" country mapping

### DIFF
--- a/config/en_US.json
+++ b/config/en_US.json
@@ -231,7 +231,7 @@
     "AI": "Anguilla",
     "VI": "U.S. Virgin Islands",
     "IS": "Iceland",
-    "IR": "Iran`",
+    "IR": "Iran",
     "AM": "Armenia",
     "AL": "Albania",
     "AO": "Angola",


### PR DESCRIPTION
We noticed this in our application as we were storing the data down and then later mapping it against a different country list. Kept getting errors that "Iran`" didn't exist and got confused about our code. Checked the API and it wasn't there, spotted it in this library.