### PR TITLE
Reject on timeout in lookupIP, lookupASN, and getMap

### DIFF
--- a/src/ipinfoWrapper.ts
+++ b/src/ipinfoWrapper.ts
@@ -179,6 +179,10 @@ export default class IPinfoWrapper {
                     }
                 });
 
+                req.on("timeout", () => {
+                    reject(new Error("timeout reached"));
+                });
+
                 req.on("error", (error) => {
                     reject(error);
                 });
@@ -258,6 +262,10 @@ export default class IPinfoWrapper {
                     }
                 });
 
+                req.on("timeout", () => {
+                    reject(new Error("timeout reached"));
+                });
+
                 req.on("error", (error) => {
                     reject(error);
                 });
@@ -325,6 +333,10 @@ export default class IPinfoWrapper {
                             });
                         }
                     }
+                });
+
+                req.on("timeout", () => {
+                    reject(new Error("timeout reached"));
                 });
 
                 req.on("error", (error) => {


### PR DESCRIPTION
Node HTTP libraries don't end the request when timeout is reached. They simply publish a new event, timeout, which needs to be handled by the client.

The getBatch function was already handling timeouts but other methods weren't.