### PR TITLE
fix: usage of `a deprecated Node.js version` in CI

### DIFF
--- a/.github/workflows/cd_npm.yml
+++ b/.github/workflows/cd_npm.yml
@@ -9,8 +9,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: 16
             - run: npm ci
@@ -21,8 +21,8 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: 16
                   registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
Fixes #97